### PR TITLE
[apple2] restore start address and fix reverse text rendering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,11 @@ ifeq ($(MAKE_COCO3),COCO3)
 	LDFLAGS_EXTRA_COCO = --org=1000 --limit=7E00
 endif
 
+ifeq ($(PLATFORM),apple2)
+	CFLAGS_EXTRA_APPLE2  += -DAPPLE2
+	LDFLAGS_EXTRA_APPLE2 += --start-addr 0x4000 --ld-args -D,__HIMEM__=0xBF00 -m $(BUILD_EXEC).map
+endif
+
 # Support 'make coco3'
 coco3:
 	$(MAKE) coco MAKE_COCO3=COCO3

--- a/apple2/src/weatherui.c
+++ b/apple2/src/weatherui.c
@@ -56,9 +56,9 @@ void change_location(LOCATION *loc) {
 	set_text();
 	clrscr();
 	gotoxy(10, 2);
-	revers(1);
+	//revers(1);
 	cprintf("Change location");
-	revers(0);
+	//revers(0);
 	gotoxy(2, 10);
 	cprintf("Input city name");
 	gotoxy(2, 11); 


### PR DESCRIPTION
- Restore Apple II linker flags
 The mekkogx migration stopped including `apple2/application.mk`, so the Apple II-specific `--start-addr 0x4000` linker setting was no longer applied.
- Disable reverse text around the change-location title 
