### PR TITLE
[apple2] fail build when main load address is below 0x4000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 !fujinet-*.lib
 fujinet-lib/
 **/_libs/
+_cache/
 
 # Shared objects (inc. Windows DLLs)
 *.dll
@@ -69,6 +70,7 @@ dist/
 obj/
 __pycache__/
 .claude/
+r2r/
 
 # emulator configs
 altirra-debug.ini

--- a/apple2/src/loadassert.s
+++ b/apple2/src/loadassert.s
@@ -1,0 +1,5 @@
+; Link-time guard: Apple II main segment must load at or above $4000 so code
+; does not overwrite Hi-Res page ($2000-$3FFF). Requires --start-addr 0x4000
+
+.import __MAIN_START__
+.assert __MAIN_START__ >= $4000, error, "Apple II load address < $4000 (need --start-addr 0x4000)"


### PR DESCRIPTION
Adds apple2/src/loadassert.s, which imports __MAIN_START__ and uses ca65/ld65 .assert with error so linking fails if the main segment would load below 0x4000.